### PR TITLE
Replace tab with space in Bitcoin OTC linkpred config

### DIFF
--- a/experiments/parameters_bitcoin_otc_linkpred_egcn_h.yaml
+++ b/experiments/parameters_bitcoin_otc_linkpred_egcn_h.yaml
@@ -23,7 +23,7 @@ dev_proportion: 0.1
 
 num_epochs: 500 #number of passes though the data
 steps_accum_gradients: 1
-learning_rate: 	0.005
+learning_rate: 0.005
 learning_rate_min: 0.005
 learning_rate_max: 0.05
 negative_mult_training: 100


### PR DESCRIPTION
The following error appears when trying trying to run the experiment defined in `parameters_bitcoin_otc_linkpred_egcn_h.yaml`:

![obraz](https://user-images.githubusercontent.com/34098778/85173521-b53edb00-b273-11ea-8a6b-070920b1cd49.png)

Changing the rogue tab character to a space fixes the error.

Sidenote: the first line of the file randomly says `data: bitcoinalpha` instead of `data: bitcoinotc`, but I'm not sure whether it's a copy-paste error type of thing or an intentional decision.